### PR TITLE
Fix bugs

### DIFF
--- a/src/commands/help/constants.js
+++ b/src/commands/help/constants.js
@@ -3,36 +3,41 @@ const config = require('../../config');
 const COMMAND_PATTERN = `(${config.prefix}|${config.shortPrefix}) help`;
 
 const TRANSLATE_HELP = [
-  { name: 'Prefix', value: '`!h` or `!habla`' },
+  {
+    name: 'Prefix',
+    value: `\`${config.shortPrefix}\` or \`${config.prefix}\``,
+  },
 
-  { name: 'Get help', value: '`!h help` or `!habla help`' },
+  {
+    name: 'Get help',
+    value: `\`${config.shortPrefix} help\` or \`${config.prefix} help\``,
+  },
 
   {
     name: 'Translate text',
-    value: '`!h french dutch Bonjour!` _(from french to dutch)_',
+    value: `\`${config.shortPrefix} french dutch Bonjour!\` _(from french to dutch)_`,
   },
 
   {
     name: "Use '?' if you don't know the original language",
-    value:
-      '`!h ? dutch Bonjour!` _(Habla will try to detect the original language)_',
+    value: `\`${config.shortPrefix} ? dutch Bonjour!\` _(Habla will try to detect the original language)_`,
   },
 
   {
     name: 'You can even use 2 letter language codes',
-    value: '`!h fr nl Bonjour!`',
+    value: `\`${config.shortPrefix} fr nl Bonjour!\``,
   },
 
   {
     name: "Translate someone else's message",
     value: `Reply to the other person's message with:
-\`!h\` _(Habla will detect the language and translate it to English)_
+\`${config.shortPrefix}\` _(Habla will detect the language and translate it to English)_
 
 Or specify the language you want to translate it to:
-\`!h french dutch\` _(from french to dutch)_
+\`${config.shortPrefix} french dutch\` _(from french to dutch)_
 
 Or use '?' if you don't know the original language:
-\`!h ? dutch\``,
+\`${config.shortPrefix} ? dutch\``,
   },
 ];
 

--- a/src/commands/translate/constants.js
+++ b/src/commands/translate/constants.js
@@ -7,7 +7,7 @@ const TRANSLATE_COMMAND_REGEXP = new RegExp(
   `^(${PREFIX})${LANGUAGES}[\\s\\n](.+)$`,
   's'
 );
-const REPLY_TRANSLATE_COMMAND_REGEXP = new RegExp(`^(${PREFIX})${LANGUAGES}?`);
+const REPLY_TRANSLATE_COMMAND_REGEXP = new RegExp(`^(${PREFIX})${LANGUAGES}?$`);
 
 module.exports = {
   TRANSLATE_COMMAND_REGEXP,

--- a/src/commands/translate/translate.command.js
+++ b/src/commands/translate/translate.command.js
@@ -39,7 +39,7 @@ const parseMessage = async message => {
   }
 
   return {
-    text,
+    text: text.normalize('NFKC'),
     from: from === '?' ? undefined : from,
     to,
   };

--- a/src/config.js
+++ b/src/config.js
@@ -7,7 +7,7 @@ module.exports = {
   googleTranslationApiKey: process.env.GOOGLE_TRANSLATION_API_KEY,
   whitelistedServers: process.env.WHITELISTED_SERVERS.split(','),
   defaultLanguage: 'en',
-  prefix: '!habla',
-  shortPrefix: '!h',
+  prefix: process.env.BOT_PREFIX || '!habla',
+  shortPrefix: process.env.BOT_SHORT_PREFIX || '!h',
   charLimit: 500,
 };

--- a/src/handlers/message.handler.js
+++ b/src/handlers/message.handler.js
@@ -35,7 +35,9 @@ const messageHandler = async message => {
     await command.handler(message);
   } else {
     logger.info('Unknown command. Sending default message');
-    message.reply('Try `!habla help` or `!h help`');
+    message.reply(
+      `Try \`${config.prefix} help\` or \`${config.shortPrefix} help\``
+    );
   }
 };
 

--- a/src/handlers/message.handler.js
+++ b/src/handlers/message.handler.js
@@ -11,7 +11,8 @@ const isBotCommand = message =>
     new RegExp(`^(${config.prefix}|${config.shortPrefix})(\\s+.*)?$`)
   );
 
-const isMentioned = message => message.mentions.has(message.client.user);
+const isMentioned = message =>
+  message.content.match(`<@!${message.client.user.id}>`);
 
 const messageHandler = async message => {
   if (message.author.bot) {

--- a/test/commands/translate.command.spec.js
+++ b/test/commands/translate.command.spec.js
@@ -323,4 +323,18 @@ describe('Translation Command', () => {
       ['That message is too long! Please limit your text to 500 characters.'],
     ]);
   });
+
+  it('should normalize unicode characters', async () => {
+    await translateTestCase(
+      mockMessage('!h en fr 𝚠𝚘𝚠 𝚝𝚑𝚊𝚝𝚜 𝚊𝚖𝚊𝚣𝚒𝚗𝚐'),
+      null,
+      {
+        from: 'French',
+        to: 'French',
+        translation: "Wouh, c'est dingue",
+      },
+      'wow thats amazing',
+      { from: 'en', to: 'fr' }
+    );
+  });
 });

--- a/test/commands/translate.command.spec.js
+++ b/test/commands/translate.command.spec.js
@@ -112,6 +112,8 @@ describe('Translation Command', () => {
       expect(match).toEqual(false);
       match = matches(mockMessage('!h en fr'));
       expect(match).toEqual(false);
+      match = matches(mockMessage('!h en', {}));
+      expect(match).toEqual(false);
     });
 
     it('should accept long prefix as well', () => {


### PR DESCRIPTION
- [x] Mention bug: If a user replies to a message from Habla, Habla treats it as a mention and sends the default help command. This should not happen unless Habla was explicitly mentioned with @

- [X] If user replies to another message for translation but sends `!h lang1 lang2 sometext`, Hable ignores `sometext` and just translates the referenced message. Although this is correct, it misleads people on how Habla commands work. Habla should treat this as incorrect usage and send the default help command
- [X] Google translate can't handle english letter equivalent unicode characters. Use `.normalize()`.
- [X] Bot prefixes `!h` and `!habla` can now optionally be overridden with ENV variables.