### PR TITLE
Fix error when sending 500 character limit message

### DIFF
--- a/src/commands/translate/translate.command.js
+++ b/src/commands/translate/translate.command.js
@@ -74,7 +74,7 @@ const handler = async message => {
   let translationResult;
 
   if (text.length > charLimit) {
-    return message.send(
+    return message.channel.send(
       `That message is too long! Please limit your text to ${charLimit} characters.`
     );
   }

--- a/test/commands/translate.command.spec.js
+++ b/test/commands/translate.command.spec.js
@@ -18,14 +18,14 @@ jest.mock('../../src/config', () => {
   };
 });
 
-const MOCK_CHANNEL = { id: '8675309' };
-
 const mockMessage = (content, reference) => {
   return {
-    channel: MOCK_CHANNEL,
+    channel: {
+      id: '8675309',
+      send: jest.fn(),
+    },
     content,
     reference,
-    send: jest.fn(),
   };
 };
 
@@ -305,11 +305,12 @@ describe('Translation Command', () => {
 
     translator.Translator.prototype.translate.mockRejectedValue(mockError);
 
-    await handler(mockMessage('!h fr en Bonjour'));
+    const message = mockMessage('!h fr en Bonjour');
+    await handler(message);
 
     expect(sendError.mock.calls).toEqual([
       [
-        MOCK_CHANNEL,
+        message.channel,
         `Google Translation Error: ${mockError.message}`,
         '```json\n' + JSON.stringify(mockError.details, null, 2) + '\n```',
       ],
@@ -320,10 +321,11 @@ describe('Translation Command', () => {
     const mockError = new Error('Oop');
     translator.Translator.prototype.translate.mockRejectedValue(mockError);
 
-    await handler(mockMessage('!h fr en Bonjour'));
+    const message = mockMessage('!h fr en Bonjour');
+    await handler(message);
 
     expect(sendError.mock.calls).toEqual([
-      [MOCK_CHANNEL, mockError.message, undefined],
+      [message.channel, mockError.message, undefined],
     ]);
   });
 
@@ -332,7 +334,7 @@ describe('Translation Command', () => {
     const message = mockMessage(`!h ? en ${lorem.generateWords(200)}`);
     await handler(message);
 
-    expect(message.send.mock.calls).toEqual([
+    expect(message.channel.send.mock.calls).toEqual([
       ['That message is too long! Please limit your text to 500 characters.'],
     ]);
   });


### PR DESCRIPTION
Previous code was incorrectly calling `message.send()` instead of `message.channel.send()` which is why the 500 character limit error message was not being sent whenever a user tried to translate a large message