### PR TITLE
patch: incorrect nickname formatting for botMentioned() fun

### DIFF
--- a/src/handlers/message.handler.js
+++ b/src/handlers/message.handler.js
@@ -12,7 +12,7 @@ const isBotCommand = message =>
   );
 
 const isMentioned = message =>
-  message.content.match(`<@!${message.client.user.id}>`);
+  message.content.match(`<@${message.client.user.id}>`);
 
 const messageHandler = async message => {
   if (message.author.bot) {


### PR DESCRIPTION
This bot uses a `<@!ID>` mention check. As per Discord API reference, these checks have been deprecated and should no longer be used.