### PR TITLE
Message Reference cleanup

### DIFF
--- a/src/commands/translate/translate.command.js
+++ b/src/commands/translate/translate.command.js
@@ -4,7 +4,6 @@ const logger = require('../../util/logger');
 const {
   sendError,
   sendTranslation,
-  fetchReferencedMessage,
   TRANSLATION_HEADER_REGEXP,
 } = require('../../util/message');
 const {
@@ -49,7 +48,7 @@ const parseMessage = async message => {
   }
 
   if (isReply(message)) {
-    const referencedMessage = await fetchReferencedMessage(message);
+    const referencedMessage = await message.fetchReference();;
     text = referencedMessage.content;
 
     if (isFromHabla(referencedMessage)) {

--- a/src/util/message.js
+++ b/src/util/message.js
@@ -20,14 +20,9 @@ const sendTranslation = (originalMessage, from, text, to, translation) => {
   originalMessage.reply(message);
 };
 
-const fetchReferencedMessage = async message => {
-  return await message.fetchReference();
-};
-
 module.exports = {
   sendError,
   sendTranslation,
-  fetchReferencedMessage,
   TRANSLATION_HEADER,
   TRANSLATION_HEADER_REGEXP,
 };


### PR DESCRIPTION
Since `fetchReferencedMessage` is only one line of code, just replace all references with that line.

***Smh, lost***