### PR TITLE
Fix help command error: use new discord.js API for sending embeds

### DIFF
--- a/src/commands/help/help.command.js
+++ b/src/commands/help/help.command.js
@@ -11,7 +11,7 @@ const handler = message => {
     )
     .addFields(TRANSLATE_HELP);
 
-  message.reply(helpMessage);
+  message.reply({ embeds: [helpMessage] });
 };
 
 module.exports = {


### PR DESCRIPTION
Using habla's `help` command results in this error

```
DiscordAPIError: Cannot send an empty message
```

Reason: https://discordjs.guide/additional-info/changes-in-v13.html#customizable-manager-caches

Using `reply(embed)` doesn't work anymore and needs to be replaced with `reply({ embeds: [embed] })` 