### PR TITLE
Handle the possibility of WHITELISTED_SERVERS being undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "habla-bot",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A discord bot that can translate text and messages between languages using Google's Cloud Translation API",
   "main": "src/index.js",
   "scripts": {

--- a/src/config.js
+++ b/src/config.js
@@ -5,9 +5,9 @@ module.exports = {
   env: process.env.NODE_ENV || 'production',
   botToken: process.env.BOT_TOKEN,
   googleTranslationApiKey: process.env.GOOGLE_TRANSLATION_API_KEY,
-  whitelistedServers: process.env.WHITELISTED_SERVERS.split(',').filter(
-    r => !!r
-  ),
+  whitelistedServers: (process.env.WHITELISTED_SERVERS || '')
+    .split(',')
+    .filter(r => !!r),
   defaultLanguage: 'en',
   prefix: process.env.BOT_PREFIX || '!habla',
   shortPrefix: process.env.BOT_SHORT_PREFIX || '!h',


### PR DESCRIPTION
Although the WHITELISTED_SERVERS env variable is optional, the bot was throwing an error when it was undefined because the code expected it to have a string value

Handle the possibility of the env variable being undefined and default it to an empty string